### PR TITLE
Data parse bug

### DIFF
--- a/R/scan_px_file.R
+++ b/R/scan_px_file.R
@@ -110,6 +110,7 @@ scan_px_file <- function(
   if (reverse_stub) {
     dimension_order <- c(metadata_output$HEADING, rev(metadata_output$STUB))
   }
+  print(dimension_order)
 
   # gather output as localized dataframe
   df <- expand.grid(dimension_order)

--- a/R/scan_px_file.R
+++ b/R/scan_px_file.R
@@ -14,6 +14,9 @@
 #'        are skipped
 #' @param encoding chose encoding as either UTF-8 or latin1
 #'        default is latin1
+#' @param reverse_stub default FALSE: decided whether the sequence
+#'                     of the data is according to the order of the
+#'                     dimensions in the stub or in the revered order
 #' @param output_dir directory for writing the output files (optional)
 #'        if not provided the output will not be offered as files
 #'
@@ -28,11 +31,13 @@
 #' @examples scan_px_file("px-x-0102020203_110.px",
 #'                        locale="en",
 #'                        encoding="UTF-8",
+#'                        reverse_stub = FALSE,
 #'                        output_dir="/tmp/")
 scan_px_file <- function(
   file_or_url,
   locale = "default",
   encoding = "latin1",
+  reverse_stub = FALSE,
   output_dir = NULL) {
   tryCatch(
     {
@@ -100,8 +105,14 @@ scan_px_file <- function(
     metadata_output <- metadata_default
   }
 
+  # order dimensions
+  dimension_order <- c(metadata_output$HEADING, metadata_output$STUB)
+  if (reverse_stub) {
+    dimension_order <- c(metadata_output$HEADING, rev(metadata_output$STUB))
+  }
+
   # gather output as localized dataframe
-  df <- expand.grid(c(metadata_output$HEADING, metadata_output$STUB))
+  df <- expand.grid(dimension_order)
   data_col_name <- paste0("data[", metadata_output$UNIT, "]")
   df[, data_col_name] <- px_cube$data
   output <- list("metadata" = metadata_output,

--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ The language code must match the language code used in the px cube and specified
 `LANGUAGES` keyword. 
 
 ``` r
-output <- scan_px_file('https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0602000000_107',
-                        locale="en")
+output <- scan_px_file(
+  'https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0602000000_107',
+  locale="en"
+)
 output$metadata
 output$dataframe
 ```
@@ -72,9 +74,10 @@ The output is structure in such a way, that it can directly be written to json o
 This is done by providing an output directory: 
 
 ``` r
-output <- scan_px_file('https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0602000000_107',
-                        locale="en",
-                        output_dir = paste0(getwd(), '/output/'))
+output <- scan_px_file(
+  'https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0602000000_107',
+  locale="en",
+  output_dir = paste0(getwd(), '/output/'))
 ```
 
 For multilingual files the output consists of the following files:
@@ -89,12 +92,38 @@ In `tests/testthat` in the directories `data` and `output` example input and
 output files are kept for testing purposes. They might also be helpful in understanding 
 how px cubes are parsed by the package.
 
-### Restrictions
+### Warnings and Restrictions
 
-In this version of the parser the following assumptions are made:
+#### Encoding
 
-- `CHARSET` is `ANSI`
-- `PX-AXIS` Version is `2010`
+Even though there is a `CODE_PAGE` specified in the px file the specified encoding
+does not always work to parse the file correctly with `scan` and `fileEncoding`.
+Therefor the encoding has been added as a parameter: `encoding`. The default is 
+`latin1`. So if the file encoding seems incorrect it can be changed to `UTF-8`:
+
+``` r
+output <- scan_px_file(
+  'https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-1002020000_101',
+  locale = "de",
+  encoding = "UTF-8")
+```
+
+#### Order of dimensions
+
+Since the px files have their data as one big array, it is essential to know
+how the dimesions are sequenced in order to crrectly map the numeric data to 
+their dimesnion attributes. It has been observed that for some 
+px files the order of dimensions is reversed. In order to allow of a correct parsing
+of these files and additional parameter has been introduced: `reverse_stub`:
+
+``` r
+output <- scan_px_file(
+  'https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0702000000_101',
+  locale = "de",
+  reverse_stub = TRUE)
+```
+
+#### Keywords
 
 Only keywords in the file `supported_keywords.csv` are currently supported.
 If an unsupported keyword is detected in the parsed px cube, the user is informed about this.

--- a/man/scan_px_file.Rd
+++ b/man/scan_px_file.Rd
@@ -8,6 +8,7 @@ scan_px_file(
   file_or_url,
   locale = "default",
   encoding = "latin1",
+  reverse_stub = FALSE,
   output_dir = NULL
 )
 }
@@ -23,6 +24,10 @@ are skipped}
 
 \item{encoding}{chose encoding as either UTF-8 or latin1
 default is latin1}
+
+\item{reverse_stub}{default FALSE: decided whether the sequence
+of the data is according to the order of the
+dimensions in the stub or in the revered order}
 
 \item{output_dir}{directory for writing the output files (optional)
 if not provided the output will not be offered as files}
@@ -45,5 +50,6 @@ The output will be stored in an output directory of choice.
 scan_px_file("px-x-0102020203_110.px",
                        locale="en",
                        encoding="UTF-8",
+                       reverse_stub = FALSE,
                        output_dir="/tmp/")
 }


### PR DESCRIPTION
This is a temporary fix for issue https://github.com/SDSC-ORD/pxRRead/issues/22. 

It adds the ability to sequence the data in a way that uses the reverse STUB order. This is needed for example for this file here: it can be parse correctly like this:

```
scan_px_file(
  "https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=px-x-0702000000_101", 
  locale = "de", 
  reverse_stub = TRUE
)
```

(Compare with StatTab: https://www.pxweb.bfs.admin.ch/pxweb/en/px-x-0702000000_101/px-x-0702000000_101/px-x-0702000000_101.px/table/tableViewLayout2/ to check that the dimensions are correctly mapped to the data)